### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/Exchange2domain.py
+++ b/Exchange2domain.py
@@ -102,7 +102,7 @@ def startServers(passargs):
             try:
                 while exp.isAlive():
                     pass
-            except KeyboardInterrupt, e:
+            except KeyboardInterrupt as e:
                 logging.info("Shutting down...")
                 for thread in serverThreads:
                     thread.server.shutdown()
@@ -143,7 +143,7 @@ def gethash(passargs):
     try:
         time.sleep(10)
         check = dumper.dump()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/comm/ntlmrelayx/attacks/__init__.py
+++ b/comm/ntlmrelayx/attacks/__init__.py
@@ -59,7 +59,7 @@ for file in pkg_resources.resource_listdir('impacket.examples.ntlmrelayx', 'atta
             else:
                 # Single class
                 pluginClasses.add(getattr(module, getattr(module, 'PROTOCOL_ATTACK_CLASS')))
-        except Exception, e:
+        except Exception as e:
             LOG.debug(e)
             pass
 
@@ -67,6 +67,6 @@ for file in pkg_resources.resource_listdir('impacket.examples.ntlmrelayx', 'atta
             for pluginName in pluginClass.PLUGIN_NAMES:
                 LOG.debug('Protocol Attack %s loaded..' % pluginName)
                 PROTOCOL_ATTACKS[pluginName] = pluginClass
-    except Exception, e:
+    except Exception as e:
         LOG.debug(str(e))
 

--- a/comm/ntlmrelayx/attacks/httpattack.py
+++ b/comm/ntlmrelayx/attacks/httpattack.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # SECUREAUTH LABS. Copyright 2018 SecureAuth Corporation. All rights reserved.
 #
 # This software is provided under under a slightly modified version
@@ -34,9 +35,9 @@ class HTTPAttack(ProtocolAttack):
         #for example with:
         result = self.client.request("GET", "/")
         r1 = self.client.getresponse()
-        print r1.status, r1.reason
+        print(r1.status, r1.reason)
         data1 = r1.read()
-        print data1
+        print(data1)
 
         #Remove protocol from target name
         #safeTargetName = self.client.target.replace('http://','').replace('https://','')

--- a/comm/ntlmrelayx/attacks/smbattack.py
+++ b/comm/ntlmrelayx/attacks/smbattack.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # SECUREAUTH LABS. Copyright 2018 SecureAuth Corporation. All rights reserved.
 #
 # This software is provided under under a slightly modified version
@@ -79,7 +80,7 @@ class SMBAttack(ProtocolAttack):
 
                 remoteOps  = RemoteOperations(self.__SMBConnection, False)
                 remoteOps.enableRegistry()
-            except Exception, e:
+            except Exception as e:
                 if "rpc_s_access_denied" in str(e): # user doesn't have correct privileges
                     if self.config.enumLocalAdmins:
                         LOG.info(u"Relayed user doesn't have admin on {}. Attempting to enumerate users who do...".format(self.__SMBConnection.getRemoteHost().encode(self.config.encoding)))
@@ -89,7 +90,7 @@ class SMBAttack(ProtocolAttack):
                             LOG.info(u"Host {} has the following local admins (hint: try relaying one of them here...)".format(self.__SMBConnection.getRemoteHost().encode(self.config.encoding)))
                             for name in localAdminNames:
                                 LOG.info(u"Host {} local admin member: {} ".format(self.__SMBConnection.getRemoteHost().encode(self.config.encoding), name))
-                        except DCERPCException, e:
+                        except DCERPCException as e:
                             LOG.info("SAMR access denied")
                         return
                 # Something else went wrong. aborting
@@ -103,7 +104,7 @@ class SMBAttack(ProtocolAttack):
                     self.__answerTMP = ''
                     self.__SMBConnection.getFile('ADMIN$', 'Temp\\__output', self.__answer)
                     self.__SMBConnection.deleteFile('ADMIN$', 'Temp\\__output')
-                    print self.__answerTMP.decode(self.config.encoding, 'replace')
+                    print(self.__answerTMP.decode(self.config.encoding, 'replace'))
                 else:
                     bootKey = remoteOps.getBootKey()
                     remoteOps._RemoteOperations__serviceDeleted = True
@@ -112,7 +113,7 @@ class SMBAttack(ProtocolAttack):
                     samHashes.dump()
                     samHashes.export(self.__SMBConnection.getRemoteHost()+'_samhashes')
                     LOG.info("Done dumping SAM hashes for host: %s", self.__SMBConnection.getRemoteHost())
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
             finally:
                 if samHashes is not None:

--- a/comm/ntlmrelayx/clients/__init__.py
+++ b/comm/ntlmrelayx/clients/__init__.py
@@ -89,13 +89,13 @@ for file in pkg_resources.resource_listdir('impacket.examples.ntlmrelayx', 'clie
                     pluginClasses.add(getattr(module, pluginClass))
             else:
                 pluginClasses.add(getattr(module, getattr(module, 'PROTOCOL_CLIENT_CLASS')))
-        except Exception, e:
+        except Exception as e:
             LOG.debug(e)
             pass
 
         for pluginClass in pluginClasses:
             LOG.info('Protocol Client %s loaded..' % pluginClass.PLUGIN_NAME)
             PROTOCOL_CLIENTS[pluginClass.PLUGIN_NAME] = pluginClass
-    except Exception, e:
+    except Exception as e:
         LOG.debug(str(e))
 

--- a/comm/ntlmrelayx/clients/mssqlrelayclient.py
+++ b/comm/ntlmrelayx/clients/mssqlrelayclient.py
@@ -115,7 +115,7 @@ class MYMSSQL(MSSQL):
         self.sendTDS(TDS_SSPI, str(token))
         tds = self.recvTDS()
         self.replies = self.parseReply(tds['Data'])
-        if self.replies.has_key(TDS_LOGINACK_TOKEN):
+        if TDS_LOGINACK_TOKEN in self.replies:
             #Once we are here, there is a full connection and we can
             #do whatever the current user has rights to do
             self.sessionData['AUTH_ANSWER'] = tds

--- a/comm/ntlmrelayx/servers/httprelayserver.py
+++ b/comm/ntlmrelayx/servers/httprelayserver.py
@@ -59,7 +59,7 @@ class HTTPRelayServer(Thread):
                 LOG.info("HTTPD: Received connection from %s, attacking target %s://%s" % (client_address[0] ,self.target.scheme, self.target.netloc))
             try:
                 SimpleHTTPServer.SimpleHTTPRequestHandler.__init__(self,request, client_address, server)
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.debug(traceback.format_exc())
 
@@ -68,7 +68,7 @@ class HTTPRelayServer(Thread):
                 SimpleHTTPServer.SimpleHTTPRequestHandler.handle_one_request(self)
             except KeyboardInterrupt:
                 raise
-            except Exception, e:
+            except Exception as e:
                 LOG.error('Exception in HTTP request handler: %s' % e)
                 LOG.debug(traceback.format_exc())
 
@@ -249,7 +249,7 @@ class HTTPRelayServer(Thread):
             return
 
         def do_ntlm_negotiate(self, token, proxy):
-            if self.server.config.protocolClients.has_key(self.target.scheme.upper()):
+            if self.target.scheme.upper() in self.server.config.protocolClients:
                 self.client = self.server.config.protocolClients[self.target.scheme.upper()](self.server.config, self.target)
                 # If connection failed, return
                 if not self.client.initConnection():
@@ -288,8 +288,9 @@ class HTTPRelayServer(Thread):
 
             return False
 
-        def checkstatus():
+        def checkstatus(self):
             return self.success
+
         def do_attack(self):
             # Check if SOCKS is enabled and if we support the target scheme
             if self.server.config.runSocks and self.target.scheme.upper() in self.server.config.socksServer.supportedSchemes:

--- a/comm/ntlmrelayx/servers/smbrelayserver.py
+++ b/comm/ntlmrelayx/servers/smbrelayserver.py
@@ -107,7 +107,7 @@ class SMBRelayServer(Thread):
         # SMBRelay
         # Get the data for all connections
         smbData = smbServer.getConnectionData('SMBRelay', False)
-        if smbData.has_key(self.target):
+        if self.target in smbData:
             # Remove the previous connection and use the last one
             smbClient = smbData[self.target]['SMBClient']
             del smbClient
@@ -125,7 +125,7 @@ class SMBRelayServer(Thread):
                 extSec = True
             # Init the correct client for our target
             client = self.init_client(extSec)
-        except Exception, e:
+        except Exception as e:
             LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
             self.targetprocessor.logTarget(self.target)
         else:
@@ -218,7 +218,7 @@ class SMBRelayServer(Thread):
                if mechType != TypesMech['NTLMSSP - Microsoft NTLM Security Support Provider'] and \
                                mechType != TypesMech['NEGOEX - SPNEGO Extended Negotiation Security Mechanism']:
                    # Nope, do we know it?
-                   if MechTypes.has_key(mechType):
+                   if mechType in MechTypes:
                        mechStr = MechTypes[mechType]
                    else:
                        mechStr = hexlify(mechType)
@@ -258,7 +258,7 @@ class SMBRelayServer(Thread):
             client = smbData[self.target]['SMBClient']
             try:
                 challengeMessage = self.do_ntlm_negotiate(client, token)
-            except Exception, e:
+            except Exception as e:
                 # Log this target as processed for this client
                 self.targetprocessor.logTarget(self.target)
                 # Raise exception again to pass it on to the SMB server
@@ -376,7 +376,7 @@ class SMBRelayServer(Thread):
         # Get the data for all connections
         smbData = smbServer.getConnectionData('SMBRelay', False)
 
-        if smbData.has_key(self.target):
+        if self.target in smbData:
             # Remove the previous connection and use the last one
             smbClient = smbData[self.target]['SMBClient']
             del smbClient
@@ -398,7 +398,7 @@ class SMBRelayServer(Thread):
 
             #Init the correct client for our target
             client = self.init_client(extSec)
-        except Exception, e:
+        except Exception as e:
             LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
             self.targetprocessor.logTarget(self.target)
         else:
@@ -457,7 +457,7 @@ class SMBRelayServer(Thread):
                 client = smbData[self.target]['SMBClient']
                 try:
                     challengeMessage = self.do_ntlm_negotiate(client,token)
-                except Exception, e:
+                except Exception as e:
                     # Log this target as processed for this client
                     self.targetprocessor.logTarget(self.target)
                     # Raise exception again to pass it on to the SMB server
@@ -645,7 +645,7 @@ class SMBRelayServer(Thread):
 
     #Initialize the correct client for the relay target
     def init_client(self,extSec):
-        if self.config.protocolClients.has_key(self.target.scheme.upper()):
+        if self.target.scheme.upper() in self.config.protocolClients:
             client = self.config.protocolClients[self.target.scheme.upper()](self.config, self.target, extendedSecurity = extSec)
             client.initConnection()
         else:

--- a/comm/ntlmrelayx/servers/socksplugins/http.py
+++ b/comm/ntlmrelayx/servers/socksplugins/http.py
@@ -62,7 +62,7 @@ class HTTPSocksRelay(SocksRelay):
                 self.username = '%s/%s' % (domain.split('.')[0], user)
 
             # Check if we have a connection for the user
-            if self.activeRelays.has_key(self.username):
+            if self.username in self.activeRelays:
                 # Check the connection is not inUse
                 if self.activeRelays[self.username]['inUse'] is True:
                     LOG.error('HTTP: Connection for %s@%s(%s) is being used at the moment!' % (

--- a/comm/ntlmrelayx/servers/socksplugins/imap.py
+++ b/comm/ntlmrelayx/servers/socksplugins/imap.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # SECUREAUTH LABS. Copyright 2018 SecureAuth Corporation. All rights reserved.
 #
 # This software is provided under under a slightly modified version
@@ -43,7 +44,7 @@ class IMAPSocksRelay(SocksRelay):
     def getServerCapabilities(self):
         for key in self.activeRelays.keys():
             if key != 'data' and key != 'scheme':
-                if self.activeRelays[key].has_key('protocolClient'):
+                if 'protocolClient' in self.activeRelays[key]:
                     return self.activeRelays[key]['protocolClient'].session.capabilities
 
     def initConnection(self):
@@ -93,7 +94,7 @@ class IMAPSocksRelay(SocksRelay):
             return False
 
         # Check if we have a connection for the user
-        if self.activeRelays.has_key(self.username):
+        if self.username in self.activeRelays:
             # Check the connection is not inUse
             if self.activeRelays[self.username]['inUse'] is True:
                 LOG.error('IMAP: Connection for %s@%s(%s) is being used at the moment!' % (
@@ -120,9 +121,9 @@ class IMAPSocksRelay(SocksRelay):
         while True:
             try:
                 data = self.socksSocket.recv(self.packetSize)
-            except Exception, e:
+            except Exception as e:
                 # Socks socket (client) closed connection or something else. Not fatal for killing the existing relay
-                print keyword, tag
+                print(keyword, tag)
                 LOG.debug('IMAP: sockSocket recv(): %s' % (str(e)))
                 break
             # If this returns with an empty string, it means the socket was closed
@@ -216,14 +217,14 @@ class IMAPSocksRelay(SocksRelay):
         while keyword != tag and keyword != '+':
             try:
                 data = self.relaySocketFile.readline()
-            except Exception, e:
+            except Exception as e:
                 # This didn't break the connection to the server, don't make it fatal
                 LOG.debug("IMAP relaySocketFile: %s" % str(e))
                 return False
             keyword = data.split(' ', 2)[0]
             try:
                 self.socksSocket.sendall(data)
-            except Exception, e:
+            except Exception as e:
                 LOG.debug("IMAP socksSocket: %s" % str(e))
                 return False
 

--- a/comm/ntlmrelayx/servers/socksplugins/imaps.py
+++ b/comm/ntlmrelayx/servers/socksplugins/imaps.py
@@ -43,7 +43,7 @@ class IMAPSSocksRelay(SSLServerMixin, IMAPSocksRelay):
                 # Shut down TLS connection
                 self.socksSocket.shutdown()
                 return False
-        except Exception, e:
+        except Exception as e:
             LOG.debug('IMAPS: %s' % str(e))
             return False
         # Change our outgoing socket to the SSL object of IMAP4_SSL

--- a/comm/ntlmrelayx/servers/socksplugins/mssql.py
+++ b/comm/ntlmrelayx/servers/socksplugins/mssql.py
@@ -114,7 +114,7 @@ class MSSQLSocksRelay(SocksRelay):
                     self.username = ('/%s' % login['UserName']).upper()
 
         # Check if we have a connection for the user
-        if self.activeRelays.has_key(self.username):
+        if self.username in self.activeRelays:
             # Check the connection is not inUse
             if self.activeRelays[self.username]['inUse'] is True:
                 LOG.error('MSSQL: Connection for %s@%s(%s) is being used at the moment!' % (
@@ -152,7 +152,7 @@ class MSSQLSocksRelay(SocksRelay):
                 tds = self.session.recvTDS()
                 # 4. Send it back to the client
                 self.sendTDS(tds['Type'], tds['Data'], 0)
-        except Exception, e:
+        except Exception as e:
             # Probably an error here
             if LOG.level == logging.DEBUG:
                 import traceback

--- a/comm/ntlmrelayx/servers/socksplugins/smb.py
+++ b/comm/ntlmrelayx/servers/socksplugins/smb.py
@@ -56,7 +56,7 @@ class SMBSocksRelay(SocksRelay):
         # We're assuming all connections to the target server use the same SMB version
         for key in activeRelays.keys():
             if key != 'data' and key != 'scheme':
-                if activeRelays[key].has_key('protocolClient'):
+                if 'protocolClient' in activeRelays[key]:
                     self.serverDialect = activeRelays[key]['protocolClient'].session.getDialect()
                     self.isSMB2 = activeRelays[key]['protocolClient'].session.getDialect() is not SMB_DIALECT
                     break
@@ -135,7 +135,7 @@ class SMBSocksRelay(SocksRelay):
                                 data2 = self.clientConnection.getSMBServer()._sess.recv_packet(timeout=1).get_trailer()
                                 self.__NBSession.send_packet(str(data))
                                 data = data2
-                        except Exception, e:
+                        except Exception as e:
                             if str(e).find('timed out') > 0:
                                 pass
                             else:
@@ -152,7 +152,7 @@ class SMBSocksRelay(SocksRelay):
                 packet['Flags'] &= ~(SMB2_FLAGS_SIGNED)
 
                 # Let's be sure the TreeConnect Table is filled with fake data
-                if self.clientConnection.getSMBServer()._Session['TreeConnectTable'].has_key(packet['TreeID']) is False:
+                if (packet['TreeID'] in self.clientConnection.getSMBServer()._Session['TreeConnectTable']) is False:
                     self.clientConnection.getSMBServer()._Session['TreeConnectTable'][packet['TreeID']] = {}
                     self.clientConnection.getSMBServer()._Session['TreeConnectTable'][packet['TreeID']]['EncryptData'] = False
 
@@ -183,12 +183,12 @@ class SMBSocksRelay(SocksRelay):
         try:
             packet = NewSMBPacket(data=data.get_trailer())
             smbCommand = SMBCommand(packet['Data'][0])
-        except Exception, e:
+        except Exception as e:
             # Maybe a SMB2 packet?
             try:
                 packet = SMB2Packet(data = data.get_trailer())
                 smbCommand = None
-            except Exception, e:
+            except Exception as e:
                 LOG.error('SOCKS: %s' % str(e))
 
         return packet, smbCommand
@@ -356,7 +356,7 @@ class SMBSocksRelay(SocksRelay):
                     username = ('%s/%s' % (authenticateMessage['domain_name'], authenticateMessage['user_name'])).upper()
 
                 # Check if we have a connection for the user
-                if self.activeRelays.has_key(username):
+                if username in self.activeRelays:
                     LOG.info('SOCKS: Proxying client session for %s@%s(445)' % (username, self.targetHost))
                     errorCode = STATUS_SUCCESS
                     smbClient = self.activeRelays[username]['protocolClient'].session
@@ -418,7 +418,7 @@ class SMBSocksRelay(SocksRelay):
                     mechType = blob['MechTypes'][0]
                     if mechType != TypesMech['NTLMSSP - Microsoft NTLM Security Support Provider']:
                         # Nope, do we know it?
-                        if MechTypes.has_key(mechType):
+                        if mechType in MechTypes:
                             mechStr = MechTypes[mechType]
                         else:
                             mechStr = hexlify(mechType)
@@ -510,7 +510,7 @@ class SMBSocksRelay(SocksRelay):
             respToken = SPNEGO_NegTokenResp()
 
             # Check if we have a connection for the user
-            if self.activeRelays.has_key(username):
+            if username in self.activeRelays:
                 LOG.info('SOCKS: Proxying client session for %s@%s(445)' % (username, self.targetHost))
                 errorCode = STATUS_SUCCESS
                 smbClient = self.activeRelays[username]['protocolClient'].session

--- a/comm/ntlmrelayx/servers/socksplugins/smtp.py
+++ b/comm/ntlmrelayx/servers/socksplugins/smtp.py
@@ -41,7 +41,7 @@ class SMTPSocksRelay(SocksRelay):
     def getServerEhlo(self):
         for key in self.activeRelays.keys():
             if key != 'data' and key != 'scheme':
-                if self.activeRelays[key].has_key('protocolClient'):
+                if 'protocolClient' in self.activeRelays[key]:
                     return self.activeRelays[key]['protocolClient'].session.ehlo_resp
 
     def initConnection(self):
@@ -100,7 +100,7 @@ class SMTPSocksRelay(SocksRelay):
             return False
 
         # Check if we have a connection for the user
-        if self.activeRelays.has_key(self.username):
+        if self.username in self.activeRelays:
             # Check the connection is not inUse
             if self.activeRelays[self.username]['inUse'] is True:
                 LOG.error('SMTP: Connection for %s@%s(%s) is being used at the moment!' % (

--- a/comm/ntlmrelayx/utils/targetsutils.py
+++ b/comm/ntlmrelayx/utils/targetsutils.py
@@ -79,7 +79,7 @@ class TargetsProcessor:
                     target = line.strip()
                     if target is not None:
                         self.originalTargets.extend(self.processTarget(target, self.protocolClients))
-        except IOError, e:
+        except IOError as e:
             LOG.error("Could not open file: %s - " % (self.filename, str(e)))
 
         if len(self.originalTargets) == 0:

--- a/comm/secretsdump.py
+++ b/comm/secretsdump.py
@@ -78,7 +78,7 @@ class DumpSecrets:
                 try:
                     try:
                         self.connect()
-                    except Exception, e:
+                    except Exception as e:
                         if os.getenv('KRB5CCNAME') is not None and self.__doKerberos is True:
                             # SMBConnection failed. That might be because there was no way to log into the
                             # target system. We just have a last resort. Hope we have tickets cached and that they
@@ -95,7 +95,7 @@ class DumpSecrets:
                         bootKey             = self.__remoteOps.getBootKey()
                         # Let's check whether target system stores LM Hashes
                         self.__noLMHash = self.__remoteOps.checkNoLMHashPolicy()
-                except Exception, e:
+                except Exception as e:
                     self.__canProcessSAMLSA = False
                     if str(e).find('STATUS_USER_SESSION_DELETED') and os.getenv('KRB5CCNAME') is not None \
                         and self.__doKerberos is True:
@@ -125,7 +125,7 @@ class DumpSecrets:
                 if self.__NTDSHashes:
                     self.cleanup()
                     return True
-            except Exception, e:
+            except Exception as e:
                 if logging.getLogger().level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
@@ -137,7 +137,7 @@ class DumpSecrets:
                         os.unlink(resumeFile)
                 self.cleanup()
                 return False
-        except (Exception, KeyboardInterrupt), e:
+        except (Exception, KeyboardInterrupt) as e:
             try:
                 self.cleanup()
             except:


### PR DESCRIPTION
* Old style exceptions --> new style for Python 3
    * Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.
* Use __print()__ function in both Python 2 and Python 3
    * Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.