### PR TITLE
Don't forget self in checkstatus()

### DIFF
--- a/comm/ntlmrelayx/servers/httprelayserver.py
+++ b/comm/ntlmrelayx/servers/httprelayserver.py
@@ -288,7 +288,7 @@ class HTTPRelayServer(Thread):
 
             return False
 
-        def checkstatus():
+        def checkstatus(self):
             return self.success
         def do_attack(self):
             # Check if SOCKS is enabled and if we support the target scheme


### PR DESCRIPTION
```
./comm/ntlmrelayx/servers/httprelayserver.py:292:20: F821 undefined name 'self'
            return self.success
                   ^
1     F821 undefined name 'self'
1
```